### PR TITLE
bugfix, initializing ClusterPool with password

### DIFF
--- a/pyredis/client.py
+++ b/pyredis/client.py
@@ -572,13 +572,14 @@ class SentinelClient(object):
         Accepts a list of sentinels in this form: [('sentinel1', 26379), ('sentinel2', 26379), ('sentinel3', 26379)]
     :type sentinels: list
     """
-    def __init__(self, sentinels):
+    def __init__(self, sentinels, password=None):
         self._conn = None
         self._sentinels = deque(sentinels)
+        self._password = password
 
     def _sentinel_connect(self, sentinel):
         host, port = sentinel
-        self._conn = Connection(host=host, port=port, conn_timeout=0.1, sentinel=True)
+        self._conn = Connection(host=host, port=port, conn_timeout=0.1, sentinel=True, password=self._password)
         try:
             self.execute('PING')
             return True

--- a/pyredis/client.py
+++ b/pyredis/client.py
@@ -571,6 +571,11 @@ class SentinelClient(object):
     :param sentinels:
         Accepts a list of sentinels in this form: [('sentinel1', 26379), ('sentinel2', 26379), ('sentinel3', 26379)]
     :type sentinels: list
+
+    :param password:
+        Password used for authentication of Sentinel instance itself. If None, no authentication is done.
+        Only available starting with Redis 5.0.1.
+    :type password: str
     """
     def __init__(self, sentinels, password=None):
         self._conn = None

--- a/pyredis/connection.py
+++ b/pyredis/connection.py
@@ -88,8 +88,6 @@ class Connection(object):
         self.database = database
 
     def _authenticate(self):
-        if self._sentinel:
-            return
         if self.password:
             self.write('AUTH', self.password)
             try:
@@ -110,8 +108,8 @@ class Connection(object):
             self._reader = Reader(encoding=self._encoding)
         else:
             self._reader = Reader()
+        self._authenticate()
         if not self._sentinel:
-            self._authenticate()
             self._setdb()
             self._set_read_only()
         self._sock.settimeout(self._read_timeout)

--- a/pyredis/helper.py
+++ b/pyredis/helper.py
@@ -38,11 +38,12 @@ def slot_from_key(key):
 
 
 class ClusterMap(object):
-    def __init__(self, seeds, lock=Lock()):
+    def __init__(self, seeds, password=None, lock=Lock()):
         self._id = uuid4()
         self._lock = lock
         self._map = {}
         self._seeds = deque(seeds)
+        self._password = password
 
     @property
     def id(self):
@@ -54,7 +55,7 @@ class ClusterMap(object):
 
     def _fetch_map(self):
         for seed in self._seeds:
-            conn = Connection(host=seed[0], port=seed[1], encoding='utf-8')
+            conn = Connection(host=seed[0], port=seed[1], encoding='utf-8', password=self._password)
             try:
                 conn.write(b'CLUSTER', b'SLOTS')
                 return conn.read()

--- a/pyredis/pool.py
+++ b/pyredis/pool.py
@@ -213,9 +213,9 @@ class ClusterPool(
     :type retries: int
     """
 
-    def __init__(self, seeds, slave_ok=False, **kwargs):
-        super().__init__(**kwargs)
-        self._map = ClusterMap(seeds=seeds)
+    def __init__(self, seeds, slave_ok=False, password=None, **kwargs):
+        super().__init__(password=password, **kwargs)
+        self._map = ClusterMap(seeds=seeds, password=password)
         self._slave_ok = slave_ok
         self._cluster = True
 

--- a/pyredis/pool.py
+++ b/pyredis/pool.py
@@ -451,6 +451,11 @@ class SentinelHashPool(
     :param retries:
         In case a sentinel delivers stale data, how many other sentinels should be tried.
     :type retries: int
+
+    :param sentinel_password:
+        Password used for authentication of Sentinel instance itself. If None, no authentication is done.
+        Only available starting with Redis 5.0.1.
+    :type sentinel_password: str
     """
     def __init__(self, sentinels, buckets, slave_ok=False, retries=3, sentinel_password=None, **kwargs):
         super().__init__(**kwargs)
@@ -612,6 +617,11 @@ class SentinelPool(
     :param retries:
         In case a sentinel delivers stale data, how many other sentinels should be tried.
     :type retries: int
+
+    :param sentinel_password:
+        Password used for authentication of Sentinel instance itself. If None, no authentication is done.
+        Only available starting with Redis 5.0.1.
+    :type sentinel_password: str
     """
     def __init__(self, sentinels, name, slave_ok=False, retries=3, sentinel_password=None, **kwargs):
         super().__init__(**kwargs)

--- a/pyredis/pool.py
+++ b/pyredis/pool.py
@@ -452,9 +452,9 @@ class SentinelHashPool(
         In case a sentinel delivers stale data, how many other sentinels should be tried.
     :type retries: int
     """
-    def __init__(self, sentinels, buckets, slave_ok=False, retries=3, **kwargs):
+    def __init__(self, sentinels, buckets, slave_ok=False, retries=3, sentinel_password=None, **kwargs):
         super().__init__(**kwargs)
-        self._sentinel = SentinelClient(sentinels=sentinels)
+        self._sentinel = SentinelClient(sentinels=sentinels, password=sentinel_password)
         self._buckets = buckets
         self._slave_ok = slave_ok
         self._retries = retries
@@ -613,9 +613,9 @@ class SentinelPool(
         In case a sentinel delivers stale data, how many other sentinels should be tried.
     :type retries: int
     """
-    def __init__(self, sentinels, name, slave_ok=False, retries=3, **kwargs):
+    def __init__(self, sentinels, name, slave_ok=False, retries=3, sentinel_password=None, **kwargs):
         super().__init__(**kwargs)
-        self._sentinel = SentinelClient(sentinels=sentinels)
+        self._sentinel = SentinelClient(sentinels=sentinels, password=sentinel_password)
         self._name = name
         self._slave_ok = slave_ok
         self._retries = retries

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -470,12 +470,12 @@ class TestSentinelClientUnit(TestCase):
         conn_mock = Mock()
         self.connection_mock.return_value = conn_mock
         sentinels = [('host1', 12345), ('host2', 12345), ('host3', 12345)]
-        client = pyredis.client.SentinelClient(sentinels=sentinels)
+        client = pyredis.client.SentinelClient(sentinels=sentinels, password='blubber')
         client.execute = Mock()
 
         self.assertTrue(client._sentinel_connect(sentinel=('host1', 12345)))
         self.connection_mock.assert_called_with(
-            host='host1', port=12345, conn_timeout=0.1, sentinel=True)
+            host='host1', port=12345, conn_timeout=0.1, sentinel=True, password='blubber')
         client.execute.assert_called_with('PING')
         self.assertEqual(client._conn, conn_mock)
 
@@ -490,7 +490,7 @@ class TestSentinelClientUnit(TestCase):
 
         self.assertFalse(client._sentinel_connect(sentinel=('host1', 12345)))
         self.connection_mock.assert_called_with(
-            host='host1', port=12345, conn_timeout=0.1, sentinel=True)
+            host='host1', port=12345, conn_timeout=0.1, sentinel=True, password=None)
         client.execute.assert_called_with('PING')
         client.close.assert_called_with()
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -517,11 +517,18 @@ class TestConnectionUnit(TestCase):
         connection._reader = reader_mock
         self.assertRaises(ReplyError, connection.read)
 
-    def test_read_exception_result_no_raise(self):
-        connection = pyredis.connection.Connection(host='127.0.0.1', encoding='utf-8')
-        connection._sock = True
+    def test_authenticate_sentinel(self):
+        connection = pyredis.connection.Connection(host='127.0.0.1', encoding='utf-8', sentinel=True)
+        authenticate_mock = Mock()
+        setdb_mock = Mock()
+        set_read_only_mock = Mock()
 
-        reader_mock = Mock()
-        reader_mock.gets.return_value = ReplyError('blub')
-        connection._reader = reader_mock
-        connection.read(raise_on_result_err=False)
+        connection._authenticate = authenticate_mock
+        connection._setdb = setdb_mock
+        connection._set_read_only = set_read_only_mock
+
+        connection._connect()
+
+        authenticate_mock.assert_called()
+        setdb_mock.assert_not_called()
+        set_read_only_mock.assert_not_called()

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -104,9 +104,10 @@ class TestClusterMap(TestCase):
         ]
 
     def test___init__(self):
-        clustermap = ClusterMap(self.seeds)
+        clustermap = ClusterMap(self.seeds, password='blubber')
         self.assertEqual(clustermap._map, {})
         self.assertEqual(clustermap._seeds, deque(self.seeds))
+        self.assertEqual(clustermap._password, 'blubber')
 
     def test__make_str(self):
         result = ClusterMap._make_str(['127.0.0.1', 7002])
@@ -118,13 +119,14 @@ class TestClusterMap(TestCase):
 
         self.connection_mock.return_value = conn1
 
-        clustermap = ClusterMap(self.seeds)
+        clustermap = ClusterMap(self.seeds, password="blubber")
 
         result = clustermap._fetch_map()
 
         self.assertEqual(result, self.map)
         conn1.write.assert_called_with(b'CLUSTER', b'SLOTS')
         self.assertTrue(conn1.close.called)
+        self.connection_mock.assert_called_with(host='host1', port=12345, encoding='utf-8', password='blubber')
 
     def test__fetch_map_second_try_ok(self):
         conn1 = Mock()
@@ -160,9 +162,9 @@ class TestClusterMap(TestCase):
         self.assertRaises(PyRedisError, clustermap._fetch_map)
 
         self.connection_mock.assert_has_calls([
-            call(host='host1', port=12345, encoding='utf-8'),
-            call(host='host2', port=12345, encoding='utf-8'),
-            call(host='host3', port=12345, encoding='utf-8')
+            call(host='host1', port=12345, encoding='utf-8', password=None),
+            call(host='host2', port=12345, encoding='utf-8', password=None),
+            call(host='host3', port=12345, encoding='utf-8', password=None)
         ])
 
         conn1.write.assert_called_with(b'CLUSTER', b'SLOTS')

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -315,7 +315,7 @@ class TestSentinelPoolUnit(TestCase):
     def test___init__default_args(self):
         pool = pyredis.pool.SentinelPool(sentinels=[('host1', 12345)], name='mymaster')
         pool._sentinel.sentinels = [('host1', 12345)]
-        self.sentinelclient_mock.assert_called_with(sentinels=[('host1', 12345)])
+        self.sentinelclient_mock.assert_called_with(sentinels=[('host1', 12345)], password=None)
         self.assertEqual(pool.name, 'mymaster')
         self.assertEqual(pool.retries, 3)
         self.assertFalse(pool.slave_ok)
@@ -327,10 +327,11 @@ class TestSentinelPoolUnit(TestCase):
             sentinels=[('host1', 12345)],
             name='mymaster',
             slave_ok=True,
-            retries=5
+            retries=5,
+            sentinel_password='blubber'
         )
         pool._sentinel.sentinels = [('host1', 12345)]
-        self.sentinelclient_mock.assert_called_with(sentinels=[('host1', 12345)])
+        self.sentinelclient_mock.assert_called_with(sentinels=[('host1', 12345)], password='blubber')
         self.assertEqual(pool.name, 'mymaster')
         self.assertEqual(pool.retries, 5)
         self.assertTrue(pool.slave_ok)

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -191,16 +191,18 @@ class TestClusterPoolUnit(TestCase):
 
         self.addCleanup(patch.stopall)
 
-        self.pool = pyredis.pool.ClusterPool(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)])
+        self.pool = pyredis.pool.ClusterPool(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)],
+                                             password='blubber')
 
     def test___init__(self):
-        self.map_mock.assert_called_with(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)])
+        self.map_mock.assert_called_with(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)],
+                                         password='blubber')
         self.assertEqual(self.pool._map, self.map_mock_inst)
         self.assertFalse(self.pool.slave_ok)
 
     def test___init__slave_ok_true(self):
         self.pool = pyredis.pool.ClusterPool(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)], slave_ok=True)
-        self.map_mock.assert_called_with(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)])
+        self.map_mock.assert_called_with(seeds=[('seed1', 12345), ('seed2', 12345), ('seed3', 12345)], password=None)
         self.assertEqual(self.pool._map, self.map_mock_inst)
         self.assertTrue(self.pool.slave_ok)
 
@@ -208,7 +210,7 @@ class TestClusterPoolUnit(TestCase):
         client = self.pool._connect()
         self.client_mock.assert_called_with(
             conn_timeout=2,
-            password=None,
+            password='blubber',
             read_timeout=2,
             cluster_map=self.pool._map,
             encoding=None,


### PR DESCRIPTION
it should pass the password attribute to ClusterMap in order to properly open a connection in ClusterMap._fetch_map method