### PR TITLE
Migrate CRC16 to upstream fix

### DIFF
--- a/pyredis/helper.py
+++ b/pyredis/helper.py
@@ -9,7 +9,7 @@ from pyredis.exceptions import PyRedisError
 from pyredis.protocol import to_bytes
 
 
-crc16 = crc.Calculator(crc.Crc16.CCITT)
+crc16 = crc.Calculator(crc.Crc16.XMODEM)
 
 
 def dict_from_list(source):

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ License: MIT (see LICENSE for details)
             'Programming Language :: Python :: 3'
     ],
     setup_requires=[
-        'crc'
+        'crc>=7.0.0'
     ],
     install_requires=[
-        'crc'
+        'crc>=7.0.0'
     ],
     keywords=[
         'redis'


### PR DESCRIPTION
this patch implements the required CRC package's migration for versions of crc > 7.0.0.  The migration is discussed here:

https://github.com/Nicoretti/crc/releases/tag/7.0.0